### PR TITLE
Include "allow-forms" value in <amp-iframe> "sandbox" attribute

### DIFF
--- a/google-amp/README.md
+++ b/google-amp/README.md
@@ -70,7 +70,7 @@ Disqus for Accelerated Mobile Pages (AMP) is a fast-loading, optimized Disqus ex
     ```html
     <amp-iframe width=600 height=140
                 layout="responsive"
-                sandbox="allow-scripts allow-same-origin allow-modals allow-popups"
+                sandbox="allow-scripts allow-same-origin allow-modals allow-popups allow-forms"
                 resizable
                 src="https://example.com/amp#hash">
     </amp-iframe>


### PR DESCRIPTION
Hi Disqus Team,

In this small edit I'm proposing the inclusion of the "allow-forms" value in <amp-iframe> "sandbox" attribute.

This is intended to support form submission in <amp-iframe>, as well as form submissions in popups spawned by <amp-iframe> (for instance, if the user needs to register an account w/ Disqus). I'm hoping this fixes an issue I'm seeing, where form-submission does not go through in the context of the account sign-in popup, but it may need more testing on your end to confirm.

Feel free to reach out with any questions!

Best,
Eric